### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/utils/httpbrute.py
+++ b/utils/httpbrute.py
@@ -23,7 +23,8 @@ def http_brute(url, username, password_file, success_string, verbose):
 
     for password in passwords:
         response = requests.post(url, data = {'username': username, 'password': password})
-        logging.info('{} {} {}'.format(username, password, response.status_code))
+        masked_password = password[0] + '*' * (len(password) - 2) + password[-1] if len(password) > 2 else '*' * len(password)
+        logging.info('{} {} {}'.format(username, masked_password, response.status_code))
         if success_string in response.text:
             print('cracked!', username, password)
             break

--- a/utils/httpbrute.py
+++ b/utils/httpbrute.py
@@ -23,8 +23,7 @@ def http_brute(url, username, password_file, success_string, verbose):
 
     for password in passwords:
         response = requests.post(url, data = {'username': username, 'password': password})
-        masked_password = password[0] + '*' * (len(password) - 2) + password[-1] if len(password) > 2 else '*' * len(password)
-        logging.info('{} {} {}'.format(username, masked_password, response.status_code))
+        logging.info('Attempted login request sent. Response status code: {}'.format(response.status_code))
         if success_string in response.text:
             print('cracked!', username, password)
             break


### PR DESCRIPTION
Potential fix for [https://github.com/SolidifyDemo/ghas-vulnerable-python/security/code-scanning/16](https://github.com/SolidifyDemo/ghas-vulnerable-python/security/code-scanning/16)

To fix the issue, we need to ensure that sensitive data, such as passwords, is not logged in clear text. Instead of logging the password, we can log a placeholder or a masked version of the password (e.g., replacing all but the first and last characters with asterisks). This approach maintains the utility of the logs for debugging purposes while protecting sensitive information.

The fix involves modifying the logging statement on line 26 to mask the password. Additionally, no other changes are required since the rest of the code does not log sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
